### PR TITLE
Odd/even and fit updates

### DIFF
--- a/leo_vetter/fits.py
+++ b/leo_vetter/fits.py
@@ -118,7 +118,7 @@ def half_trapezoid(tlc, side):
         tlc.metrics[f"trap_qtran_err_{side}"] = np.nan
 
 
-def transit(tlc, u1, u2, cap_b=True):
+def transit(tlc, u1, u2, cap_b=False):
     tlc.metrics["transit_u1"] = u1
     tlc.metrics["transit_u2"] = u2
     try:

--- a/leo_vetter/main.py
+++ b/leo_vetter/main.py
@@ -137,7 +137,7 @@ class TCELightCurve:
         self.metrics["SHP"] = Fmax / (Fmax - Fmin)
 
     def compute_flux_metrics(
-        self, star, verbose=True, cap_b=True, frac=0.7, chases=0.01, rubble=0.75, A=0.3
+        self, star, verbose=True, cap_b=False, frac=0.7, chases=0.01, rubble=0.75, A=0.3
     ):
         if verbose:
             print("Estimating SES and MES time series...")

--- a/leo_vetter/main.py
+++ b/leo_vetter/main.py
@@ -106,13 +106,19 @@ class TCELightCurve:
             in_bin = in_tran & ~self.near_tran
             bin_flux[i] = weighted_mean(self.flux[in_bin], self.flux_err[in_bin])
             bin_flux_err[i] = weighted_err(self.flux[in_bin], self.flux_err[in_bin])
+        # Estimate white and red noise following Hartman & Bakos (2016)
         mask = ~np.isnan(bin_flux) & ~self.near_tran
-        # White noise is std of residual light curve
-        self.sig_w = weighted_std(self.flux[mask], self.flux_err[mask])
-        # Red noise is std of binned residual light curve
-        sig_r = weighted_std(bin_flux[mask], bin_flux_err[mask])
-        self.sig_r = sig_r if ~np.isnan(sig_r) else 0
-        # Combine white and red noise to get pink noise following Pont et al. (2006)
+        std = weighted_std(self.flux[mask], self.flux_err[mask])
+        bin_std = weighted_std(bin_flux[mask], bin_flux_err[mask])
+        expected_bin_std = (
+            std
+            * np.sqrt(np.nanmean(bin_flux_err[mask] ** 2))
+            / np.sqrt(np.nanmean(self.flux_err[mask] ** 2))
+        )
+        self.sig_w = std
+        sig_r2 = bin_std**2 - expected_bin_std**2
+        self.sig_r = np.sqrt(sig_r2) if sig_r2 > 0 else 0
+        # Estimate signal-to-pink-noise following Pont et al. (2006)
         self.err = np.sqrt(
             (self.sig_w**2 / self.n_in) + (self.sig_r**2 / self.N_transit)
         )

--- a/leo_vetter/oddeven.py
+++ b/leo_vetter/oddeven.py
@@ -120,7 +120,7 @@ def trapezoid(tlc):
     )
 
 
-def transit(tlc, cap_b=True):
+def transit(tlc, cap_b=False):
     try:
         if np.isnan(tlc.metrics["transit_aic"]):
             raise ValueError

--- a/leo_vetter/oddeven.py
+++ b/leo_vetter/oddeven.py
@@ -18,23 +18,25 @@ def box(tlc):
         odd_dep = tlc.zpt - weighted_mean(
             tlc.flux[tlc.odd_tran], tlc.flux_err[tlc.odd_tran]
         )
-        odd_err = np.sqrt((tlc.sig_w**2 / n_in) + (tlc.sig_r**2 / N_transit))
+        odd_dep_err = np.sqrt((tlc.sig_w**2 / n_in) + (tlc.sig_r**2 / N_transit))
     else:
-        odd_dep, odd_err = np.nan, np.nan
+        odd_dep, odd_dep_err = np.nan, np.nan
     if np.any(tlc.even_tran):
         n_in = np.sum(tlc.even_tran)
         N_transit = len(np.unique(tlc.epochs[tlc.even_tran]))
         even_dep = tlc.zpt - weighted_mean(
             tlc.flux[tlc.even_tran], tlc.flux_err[tlc.even_tran]
         )
-        even_err = np.sqrt((tlc.sig_w**2 / n_in) + (tlc.sig_r**2 / N_transit))
+        even_dep_err = np.sqrt((tlc.sig_w**2 / n_in) + (tlc.sig_r**2 / N_transit))
     else:
-        even_dep, even_err = np.nan, np.nan
+        even_dep, even_dep_err = np.nan, np.nan
     tlc.metrics["odd_dep"] = odd_dep
-    tlc.metrics["odd_err"] = odd_err
+    tlc.metrics["odd_dep_err"] = odd_dep_err
     tlc.metrics["even_dep"] = even_dep
-    tlc.metrics["even_err"] = even_err
-    tlc.metrics["sig_oe"] = diff_significance(odd_dep, even_dep, odd_err, even_err)
+    tlc.metrics["even_dep_err"] = even_dep_err
+    tlc.metrics["sig_dep"] = diff_significance(
+        odd_dep, even_dep, odd_dep_err, even_dep_err
+    )
 
 
 def trapezoid(tlc):
@@ -49,12 +51,14 @@ def trapezoid(tlc):
             tlc.metrics["trap_qin"],
             tlc.metrics["trap_zpt"],
         )
-        for param in ["per", "epo", "qtran", "qin", "zpt"]:
+        for param in ["per", "qtran", "qin", "zpt"]:
             tm.params[param].vary = False
         phase = np.mod(tlc.time - tlc.epo, 2 * tlc.per) / tlc.per
         phase[phase > 1] -= 2
-        odd_dep, odd_err = np.nan, np.nan
-        even_dep, even_err = np.nan, np.nan
+        odd_dep, odd_dep_err = np.nan, np.nan
+        odd_epo, odd_epo_err = np.nan, np.nan
+        even_dep, even_dep_err = np.nan, np.nan
+        even_epo, even_epo_err = np.nan, np.nan
         if np.any(tlc.odd_tran):
             fit_tran = abs(phase) < 2 * tlc.qtran
             odd_fit = minimize(
@@ -64,9 +68,13 @@ def trapezoid(tlc):
             )
             if odd_fit.success:
                 odd_dep = odd_fit.params["dep"].value
-                odd_err = odd_fit.params["dep"].stderr
-                if odd_err is None:
-                    odd_err = np.nan
+                odd_dep_err = odd_fit.params["dep"].stderr
+                odd_epo = odd_fit.params["epo"].value
+                odd_epo_err = odd_fit.params["epo"].stderr
+                if odd_dep_err is None:
+                    odd_dep_err = np.nan
+                if odd_epo_err is None:
+                    odd_epo_err = np.nan
         if np.any(tlc.even_tran):
             fit_tran = abs(phase) > 1 - 2 * tlc.qtran
             even_fit = minimize(
@@ -76,22 +84,40 @@ def trapezoid(tlc):
             )
             if even_fit.success:
                 even_dep = even_fit.params["dep"].value
-                even_err = even_fit.params["dep"].stderr
-                if even_err is None:
-                    even_err = np.nan
+                even_dep_err = even_fit.params["dep"].stderr
+                even_epo = even_fit.params["epo"].value
+                even_epo_err = even_fit.params["epo"].stderr
+                if even_dep_err is None:
+                    even_dep_err = np.nan
+                if even_epo_err is None:
+                    even_epo_err = np.nan
     except Exception:
         print(f"{tlc.tic}.{tlc.planetno}: failed odd/even trapezoid fit")
         tlc.metrics["trap_odd_dep"] = np.nan
-        tlc.metrics["trap_odd_err"] = np.nan
+        tlc.metrics["trap_odd_dep_err"] = np.nan
         tlc.metrics["trap_even_dep"] = np.nan
-        tlc.metrics["trap_even_err"] = np.nan
-        tlc.metrics["trap_sig_oe"] = np.nan
+        tlc.metrics["trap_even_dep_err"] = np.nan
+        tlc.metrics["trap_odd_epo"] = np.nan
+        tlc.metrics["trap_odd_epo_err"] = np.nan
+        tlc.metrics["trap_even_epo"] = np.nan
+        tlc.metrics["trap_even_epo_err"] = np.nan
+        tlc.metrics["trap_sig_dep"] = np.nan
+        tlc.metrics["trap_sig_epo"] = np.nan
         return
     tlc.metrics["trap_odd_dep"] = odd_dep
-    tlc.metrics["trap_odd_err"] = odd_err
+    tlc.metrics["trap_odd_dep_err"] = odd_dep_err
     tlc.metrics["trap_even_dep"] = even_dep
-    tlc.metrics["trap_even_err"] = even_err
-    tlc.metrics["trap_sig_oe"] = diff_significance(odd_dep, even_dep, odd_err, even_err)
+    tlc.metrics["trap_even_dep_err"] = even_dep_err
+    tlc.metrics["trap_odd_epo"] = odd_epo
+    tlc.metrics["trap_odd_epo_err"] = odd_epo_err
+    tlc.metrics["trap_even_epo"] = even_epo
+    tlc.metrics["trap_even_epo_err"] = even_epo_err
+    tlc.metrics["trap_sig_dep"] = diff_significance(
+        odd_dep, even_dep, odd_dep_err, even_dep_err
+    )
+    tlc.metrics["trap_sig_epo"] = diff_significance(
+        odd_epo, even_epo, odd_epo_err, even_epo_err
+    )
 
 
 def transit(tlc, cap_b=True):
@@ -109,12 +135,14 @@ def transit(tlc, cap_b=True):
             tlc.metrics["transit_zpt"],
             cap_b=cap_b,
         )
-        for param in ["per", "epo", "b", "aRs", "zpt"]:
+        for param in ["per", "b", "aRs", "zpt"]:
             tm.params[param].vary = False
         phase = np.mod((tlc.time - tlc.epo) / tlc.per, 2)
         phase[phase > 1] -= 2
-        odd_RpRs, odd_err = np.nan, np.nan
-        even_RpRs, even_err = np.nan, np.nan
+        odd_RpRs, odd_RpRs_err = np.nan, np.nan
+        odd_epo, odd_epo_err = np.nan, np.nan
+        even_RpRs, even_RpRs_err = np.nan, np.nan
+        even_epo, even_epo_err = np.nan, np.nan
         if np.any(tlc.odd_tran):
             fit_tran = abs(phase) < 2 * tlc.qtran
             odd_fit = minimize(
@@ -124,9 +152,13 @@ def transit(tlc, cap_b=True):
             )
             if odd_fit.success:
                 odd_RpRs = odd_fit.params["RpRs"].value
-                odd_err = odd_fit.params["RpRs"].stderr
-                if odd_err is None:
-                    odd_err = np.nan
+                odd_RpRs_err = odd_fit.params["RpRs"].stderr
+                odd_epo = odd_fit.params["epo"].value
+                odd_epo_err = odd_fit.params["epo"].stderr
+                if odd_RpRs_err is None:
+                    odd_RpRs_err = np.nan
+                if odd_epo_err is None:
+                    odd_epo_err = np.nan
         if np.any(tlc.even_tran):
             fit_tran = abs(phase) > 1 - 2 * tlc.qtran
             even_fit = minimize(
@@ -136,21 +168,37 @@ def transit(tlc, cap_b=True):
             )
             if even_fit.success:
                 even_RpRs = even_fit.params["RpRs"].value
-                even_err = even_fit.params["RpRs"].stderr
-                if even_err is None:
-                    even_err = np.nan
+                even_RpRs_err = even_fit.params["RpRs"].stderr
+                even_epo = even_fit.params["epo"].value
+                even_epo_err = even_fit.params["epo"].stderr
+                if even_RpRs_err is None:
+                    even_RpRs_err = np.nan
+                if even_epo_err is None:
+                    even_epo_err = np.nan
     except Exception:
         print(f"{tlc.tic}.{tlc.planetno}: failed odd/even transit fit")
         tlc.metrics["transit_odd_RpRs"] = np.nan
+        tlc.metrics["transit_odd_RpRs_err"] = np.nan
         tlc.metrics["transit_even_RpRs"] = np.nan
-        tlc.metrics["transit_odd_err"] = np.nan
-        tlc.metrics["transit_even_err"] = np.nan
-        tlc.metrics["transit_sig_oe"] = np.nan
+        tlc.metrics["transit_even_RpRs_err"] = np.nan
+        tlc.metrics["transit_odd_epo"] = np.nan
+        tlc.metrics["transit_odd_epo_err"] = np.nan
+        tlc.metrics["transit_even_epo"] = np.nan
+        tlc.metrics["transit_even_epo_err"] = np.nan
+        tlc.metrics["transit_sig_dep"] = np.nan
+        tlc.metrics["transit_sig_epo"] = np.nan
         return
     tlc.metrics["transit_odd_RpRs"] = odd_RpRs
+    tlc.metrics["transit_odd_RpRs_err"] = odd_RpRs_err
     tlc.metrics["transit_even_RpRs"] = even_RpRs
-    tlc.metrics["transit_odd_err"] = odd_err
-    tlc.metrics["transit_even_err"] = even_err
-    tlc.metrics["transit_sig_oe"] = diff_significance(
-        odd_RpRs, even_RpRs, odd_err, even_err
+    tlc.metrics["transit_even_RpRs_err"] = even_RpRs_err
+    tlc.metrics["transit_odd_epo"] = odd_epo
+    tlc.metrics["transit_odd_epo_err"] = odd_epo_err
+    tlc.metrics["transit_even_epo"] = even_epo
+    tlc.metrics["transit_even_epo_err"] = even_epo_err
+    tlc.metrics["transit_sig_dep"] = diff_significance(
+        odd_RpRs, even_RpRs, odd_RpRs_err, even_RpRs_err
+    )
+    tlc.metrics["transit_sig_epo"] = diff_significance(
+        odd_epo, even_epo, odd_epo_err, even_epo_err
     )

--- a/leo_vetter/plots.py
+++ b/leo_vetter/plots.py
@@ -475,9 +475,11 @@ def transit_setup(tlc):
     model = tm.model(tm.params, mtime)
     odd_params = tm.params
     odd_params["RpRs"].value = tlc.metrics["transit_odd_RpRs"]
+    odd_params["epo"].value = tlc.metrics["transit_odd_epo"]
     odd_model = tm.model(odd_params, mtime)
     even_params = tm.params
     even_params["RpRs"].value = tlc.metrics["transit_even_RpRs"]
+    even_params["epo"].value = tlc.metrics["transit_even_epo"]
     even_model = tm.model(even_params, mtime)
     return per, epo, dur, mtime, model, odd_model, even_model
 
@@ -498,9 +500,11 @@ def trapezoid_setup(tlc):
     model = tm.model(tm.params, mtime)
     odd_params = tm.params
     odd_params["dep"].value = tlc.metrics["trap_odd_dep"]
+    odd_params["epo"].value = tlc.metrics["trap_odd_epo"]
     odd_model = tm.model(odd_params, mtime)
     even_params = tm.params
     even_params["dep"].value = tlc.metrics["trap_even_dep"]
+    even_params["epo"].value = tlc.metrics["trap_even_epo"]
     even_model = tm.model(even_params, mtime)
     return per, epo, dur, mtime, model, odd_model, even_model
 
@@ -549,7 +553,7 @@ def plot_summary(tlc, star, save_fig=False, save_file=None):
         axClose.plot((mtime - epo) * 24, model, "r")
     # Plot odd transits
     plot_odd_even(
-        axOdd, axEven, tlc.time, tlc.flux, per, epo, dur, tlc.metrics["trap_sig_oe"]
+        axOdd, axEven, tlc.time, tlc.flux, per, epo, dur, tlc.metrics["trap_sig_dep"]
     )
     if plot_model:
         axOdd.plot((mtime - epo) * 24, odd_model, color=_odd_colour)
@@ -646,7 +650,7 @@ def plot_summary_with_diff(
         axClose.plot((mtime - epo) * 24, model, "r")
     # Plot odd transits
     plot_odd_even(
-        axOdd, axEven, tlc.time, tlc.flux, per, epo, dur, tlc.metrics["trap_sig_oe"]
+        axOdd, axEven, tlc.time, tlc.flux, per, epo, dur, tlc.metrics["trap_sig_dep"]
     )
     if plot_model:
         axOdd.plot((mtime - epo) * 24, odd_model, color=_odd_colour)
@@ -764,7 +768,14 @@ def plot_summary_with_diff(
 
 
 def plot_diffimages(
-    tic, planetno, tdi, sectors, pixel_data, annotate=False, save_fig=False, save_file=None
+    tic,
+    planetno,
+    tdi,
+    sectors,
+    pixel_data,
+    annotate=False,
+    save_fig=False,
+    save_file=None,
 ):
     n_sectors = len(sectors)
     fs = 10

--- a/leo_vetter/thresholds.py
+++ b/leo_vetter/thresholds.py
@@ -98,12 +98,12 @@ def odd_even(metrics):
     # Checks for differences between odd and even transits
     message = "FP: odd-even transit differences"
     dep_diff = metrics["trap_sig_dep"] > 3
-    epo_diff = metrics["trap_sig_epo"] > 3
+    epo_diff = metrics["trap_sig_epo"] > 10
     # The planet may have no odd or even transits
     wrong_period = (metrics["odd_dep"] < 3 * metrics["odd_dep_err"]) | (
         metrics["even_dep"] < 3 * metrics["even_dep_err"]
     )
-    return (dep_diff | epo_diff) & ~wrong_period, message
+    return (dep_diff & ~wrong_period) | epo_diff, message
 
 
 def vshaped(metrics):

--- a/leo_vetter/thresholds.py
+++ b/leo_vetter/thresholds.py
@@ -9,13 +9,13 @@ def weak(metrics):
 
 def invalid_transits(metrics):
     # Checks the number of "good" transits left after removing all the "bad" transits
-    message="FA: not enough valid transits"
+    message = "FA: not enough valid transits"
     return (metrics["new_N_transit"] < 2), message
 
 
 def noisy(metrics):
     # Checks the amount of systematic red noise in the light curve
-    message="FA: too much noise at transit timescale"
+    message = "FA: too much noise at transit timescale"
     return metrics["Fred"] > 4, message
 
 
@@ -24,13 +24,13 @@ def bad_shape(metrics):
     # SHP = 0.0 means the event only decreases the flux
     # SHP = 0.5 means the event has both increases and decreases in flux
     # SHP = 1.0 means the event only increases the flux
-    message="FA: bad transit shape"
+    message = "FA: bad transit shape"
     return (metrics["SHP"] > 0.4) & (metrics["per"] < 10), message
 
 
 def non_unique(metrics):
     # Checks the uniqueness of the event compared to noise/other events
-    message="FA: events not unique in phased light curve"
+    message = "FA: events not unique in phased light curve"
     MS1 = (metrics["sig_pri"] / metrics["Fred"] - metrics["FA1"]) < 3
     MS2 = (metrics["sig_pri"] - metrics["sig_ter"] - metrics["FA2"]) < 1
     MS3 = (metrics["sig_pri"] - metrics["sig_pos"] - metrics["FA2"]) < 0
@@ -39,19 +39,19 @@ def non_unique(metrics):
 
 def chases(metrics):
     # Checks the uniqueness of each individual event compared to the local light curve
-    message="FA: events not unique in local light curve"
+    message = "FA: events not unique in local light curve"
     return (metrics["N_transit"] <= 5) & (metrics["med_chases"] < 0.8), message
 
 
 def dmm(metrics):
     # Checks for consistency between the mean and median transit depths
-    message="FA: inconsistent transit depths"
+    message = "FA: inconsistent transit depths"
     return metrics["DMM"] > 1.5, message
 
 
 def single_event(metrics):
     # Checks for single events dominating the MES
-    message="FA: dominated by single event"
+    message = "FA: dominated by single event"
     return (metrics["max_SES"] / metrics["MES"] > 0.8) & (
         metrics["N_transit"] <= 5
     ), message
@@ -59,7 +59,7 @@ def single_event(metrics):
 
 def bad_fit(metrics):
     # Checks that a transit model fit is preferred over a straight line
-    message="FA: bad transit model fit"
+    message = "FA: bad transit model fit"
     fit_failed = np.isnan(metrics["transit_aic"])
     chisqr = metrics["transit_chisqr"] > metrics["line_chisqr"]
     aic = metrics["transit_aic"] - metrics["line_aic"] > -20
@@ -68,13 +68,13 @@ def bad_fit(metrics):
 
 def sinusoidal(metrics):
     # Checks for sinusoidal variations in the phased light curve
-    message="FA: sinusoidal variations"
+    message = "FA: sinusoidal variations"
     return (metrics["sine_sig"] > 10) & (metrics["per"] < 10), message
 
 
 def unphysical_duration(metrics):
     # Checks that the orbit is physically realistic
-    message="FA: unphysical transit orbit"
+    message = "FA: unphysical transit orbit"
     low_aRs = (metrics["transit_aRs"] < 1.5) | (metrics["aRs"] < 2)
     long_duration = (
         (metrics["q"] / metrics["trap_qtran"] < 0.5)
@@ -86,7 +86,7 @@ def unphysical_duration(metrics):
 
 def asymmetric(metrics):
     # Checks for transit asymmetry
-    message="FA: asymmetric events"
+    message = "FA: asymmetric events"
     diff = abs(metrics["trap_qtran_left"] - metrics["trap_qtran_right"])
     err = np.sqrt(
         metrics["trap_qtran_err_left"] ** 2 + metrics["trap_qtran_err_right"] ** 2
@@ -95,31 +95,32 @@ def asymmetric(metrics):
 
 
 def odd_even(metrics):
-    # Checks for differences between odd and even transit depths
-    message="FP: odd-even depth differences"
-    odd_even = metrics["trap_sig_oe"] > 4
+    # Checks for differences between odd and even transits
+    message = "FP: odd-even transit differences"
+    dep_diff = metrics["trap_sig_dep"] > 3
+    epo_diff = metrics["trap_sig_epo"] > 3
     # The planet may have no odd or even transits
-    wrong_period = (metrics["odd_dep"] < 3 * metrics["odd_err"]) | (
-        metrics["even_dep"] < 3 * metrics["even_err"]
+    wrong_period = (metrics["odd_dep"] < 3 * metrics["odd_dep_err"]) | (
+        metrics["even_dep"] < 3 * metrics["even_dep_err"]
     )
-    return (odd_even & ~wrong_period), message
+    return (dep_diff | epo_diff) & ~wrong_period, message
 
 
 def vshaped(metrics):
-    message="FP: V-shaped events"
+    message = "FP: V-shaped events"
     # Checks for both large and highly grazing objects
     return (metrics["transit_b"] + metrics["transit_RpRs"]) > 1.5, message
 
 
 def large(metrics):
     # Checks the radius of the object
-    message="FP: radius too large"
+    message = "FP: radius too large"
     return metrics["Rp"] > 25, message
 
 
 def secondary(metrics):
     # Checks for the existence of a significant secondary eclipse
-    message="FP: significant secondary"
+    message = "FP: significant secondary"
     MS1 = ((metrics["sig_sec"] / metrics["Fred"] - metrics["FA1"]) > 1) | (
         metrics["Fred"] > 2
     )
@@ -145,7 +146,7 @@ def secondary(metrics):
 
 def offset(metrics):
     # Checks for offset between PRF fit and star location
-    message="FP: off-target"
+    message = "FP: off-target"
     return metrics["offset"] > 0.4, message
 
 

--- a/tutorials/user_thresholds.py
+++ b/tutorials/user_thresholds.py
@@ -9,13 +9,13 @@ def weak(metrics):
 
 def invalid_transits(metrics):
     # Checks the number of "good" transits left after removing all the "bad" transits
-    message="FA: not enough valid transits"
+    message = "FA: not enough valid transits"
     return (metrics["new_N_transit"] < 2), message
 
 
 def noisy(metrics):
     # Checks the amount of systematic red noise in the light curve
-    message="FA: too much noise at transit timescale"
+    message = "FA: too much noise at transit timescale"
     return metrics["Fred"] > 4, message
 
 
@@ -24,13 +24,13 @@ def bad_shape(metrics):
     # SHP = 0.0 means the event only decreases the flux
     # SHP = 0.5 means the event has both increases and decreases in flux
     # SHP = 1.0 means the event only increases the flux
-    message="FA: bad transit shape"
+    message = "FA: bad transit shape"
     return (metrics["SHP"] > 0.4) & (metrics["per"] < 10), message
 
 
 def non_unique(metrics):
     # Checks the uniqueness of the event compared to noise/other events
-    message="FA: events not unique in phased light curve"
+    message = "FA: events not unique in phased light curve"
     MS1 = (metrics["sig_pri"] / metrics["Fred"] - metrics["FA1"]) < 3
     MS2 = (metrics["sig_pri"] - metrics["sig_ter"] - metrics["FA2"]) < 1
     MS3 = (metrics["sig_pri"] - metrics["sig_pos"] - metrics["FA2"]) < 0
@@ -39,19 +39,19 @@ def non_unique(metrics):
 
 def chases(metrics):
     # Checks the uniqueness of each individual event compared to the local light curve
-    message="FA: events not unique in local light curve"
+    message = "FA: events not unique in local light curve"
     return (metrics["N_transit"] <= 5) & (metrics["med_chases"] < 0.8), message
 
 
 def dmm(metrics):
     # Checks for consistency between the mean and median transit depths
-    message="FA: inconsistent transit depths"
+    message = "FA: inconsistent transit depths"
     return metrics["DMM"] > 1.5, message
 
 
 def single_event(metrics):
     # Checks for single events dominating the MES
-    message="FA: dominated by single event"
+    message = "FA: dominated by single event"
     return (metrics["max_SES"] / metrics["MES"] > 0.8) & (
         metrics["N_transit"] <= 5
     ), message
@@ -59,7 +59,7 @@ def single_event(metrics):
 
 def bad_fit(metrics):
     # Checks that a transit model fit is preferred over a straight line
-    message="FA: bad transit model fit"
+    message = "FA: bad transit model fit"
     fit_failed = np.isnan(metrics["transit_aic"])
     chisqr = metrics["transit_chisqr"] > metrics["line_chisqr"]
     aic = metrics["transit_aic"] - metrics["line_aic"] > -20
@@ -68,13 +68,13 @@ def bad_fit(metrics):
 
 def sinusoidal(metrics):
     # Checks for sinusoidal variations in the phased light curve
-    message="FA: sinusoidal variations"
+    message = "FA: sinusoidal variations"
     return (metrics["sine_sig"] > 10) & (metrics["per"] < 10), message
 
 
 def unphysical_duration(metrics):
     # Checks that the orbit is physically realistic
-    message="FA: unphysical transit orbit"
+    message = "FA: unphysical transit orbit"
     low_aRs = (metrics["transit_aRs"] < 1.5) | (metrics["aRs"] < 2)
     long_duration = (
         (metrics["q"] / metrics["trap_qtran"] < 0.5)
@@ -86,7 +86,7 @@ def unphysical_duration(metrics):
 
 def asymmetric(metrics):
     # Checks for transit asymmetry
-    message="FA: asymmetric events"
+    message = "FA: asymmetric events"
     diff = abs(metrics["trap_qtran_left"] - metrics["trap_qtran_right"])
     err = np.sqrt(
         metrics["trap_qtran_err_left"] ** 2 + metrics["trap_qtran_err_right"] ** 2
@@ -95,31 +95,32 @@ def asymmetric(metrics):
 
 
 def odd_even(metrics):
-    # Checks for differences between odd and even transit depths
-    message="FP: odd-even depth differences"
-    odd_even = metrics["trap_sig_oe"] > 4
+    # Checks for differences between odd and even transits
+    message = "FP: odd-even transit differences"
+    dep_diff = metrics["trap_sig_dep"] > 3
+    epo_diff = metrics["trap_sig_epo"] > 10
     # The planet may have no odd or even transits
-    wrong_period = (metrics["odd_dep"] < 3 * metrics["odd_err"]) | (
-        metrics["even_dep"] < 3 * metrics["even_err"]
+    wrong_period = (metrics["odd_dep"] < 3 * metrics["odd_dep_err"]) | (
+        metrics["even_dep"] < 3 * metrics["even_dep_err"]
     )
-    return (odd_even & ~wrong_period), message
+    return (dep_diff & ~wrong_period) | epo_diff, message
 
 
 def vshaped(metrics):
-    message="FP: V-shaped events"
+    message = "FP: V-shaped events"
     # Checks for both large and highly grazing objects
     return (metrics["transit_b"] + metrics["transit_RpRs"]) > 1.5, message
 
 
 def large(metrics):
     # Checks the radius of the object
-    message="FP: radius too large"
+    message = "FP: radius too large"
     return metrics["Rp"] > 25, message
 
 
 def secondary(metrics):
     # Checks for the existence of a significant secondary eclipse
-    message="FP: significant secondary"
+    message = "FP: significant secondary"
     MS1 = ((metrics["sig_sec"] / metrics["Fred"] - metrics["FA1"]) > 1) | (
         metrics["Fred"] > 2
     )
@@ -145,7 +146,7 @@ def secondary(metrics):
 
 def offset(metrics):
     # Checks for offset between PRF fit and star location
-    message="FP: off-target"
+    message = "FP: off-target"
     return metrics["offset"] > 0.4, message
 
 


### PR DESCRIPTION
- updates the odd-even transit test to fit for changes in transit time instead of just depth, meant to catch cases where an EB on a slightly eccentric orbit can be picked up at the wrong period
- changes default transit model fit to let impact parameter be > 1 instead of capped
- slight adjustments to pass/fail thresholds to reflect the above changes