### PR TITLE
Optimization of SES/MES computation

### DIFF
--- a/leo_vetter/main.py
+++ b/leo_vetter/main.py
@@ -104,18 +104,27 @@ class TCELightCurve:
             dep_SES[i] = self.zpt - weighted_mean(self.flux[left_idx:right_idx], self.flux_err[left_idx:right_idx])
             
             # Get overall transit depth at this cadence, i.e. use all datapoints close in phase
+            p = phase[i]
             
             # find indices within +- range from the current phase index
-            left_p  = np.searchsorted(phase_sorted, phase[i] - dur_per_frac_half, side='right')
-            right_p = np.searchsorted(phase_sorted, phase[i] + dur_per_frac_half, side='left')
+            left_p  = np.searchsorted(phase_sorted, p - dur_per_frac_half, side='right')
+            right_p = np.searchsorted(phase_sorted, p + dur_per_frac_half, side='left')
             idx_window = phase_sorted_idxs[left_p:right_p]
 
-            left_p_wrap  = np.searchsorted(phase_sorted, phase[i] - dur_per_frac_half + 1.0, side='right')
-            right_p_wrap = np.searchsorted(phase_sorted, phase[i] + dur_per_frac_half + 1.0, side='left')
-            idx_window_wrap = phase_sorted_idxs[left_p_wrap:right_p_wrap]
+            # handle phase wrapping
+            if p < dur_per_frac_half:
+                wrap = np.searchsorted(phase_sorted, p - dur_per_frac_half + 1.0, side='left')
+                idx_wrap = phase_sorted_idxs[wrap:]
+                all_tran_idxs = np.concatenate((idx_window, idx_wrap))
+            elif p > (1.0 - dur_per_frac_half):
+                wrap = np.searchsorted(phase_sorted, p + dur_per_frac_half - 1.0, side='right')
+                idx_wrap = phase_sorted_idxs[:wrap]
+                all_tran_idxs = np.concatenate((idx_window, idx_wrap))
+            else:
+                all_tran_idxs = idx_window
 
-            # combine the two windows
-            all_tran_idxs = np.concatenate((idx_window, idx_window_wrap))
+            # avoid possible duplicates
+            all_tran_idxs = np.unique(all_tran_idxs)
             
             n_MES[i] = len(all_tran_idxs)
             dep_MES[i] = self.zpt - weighted_mean(self.flux[all_tran_idxs], self.flux_err[all_tran_idxs])

--- a/leo_vetter/main.py
+++ b/leo_vetter/main.py
@@ -84,28 +84,54 @@ class TCELightCurve:
         bin_flux_err = np.zeros(N)
         phase = phasefold(self.time, self.per, self.epo)
         phase[phase < 0] += 1
+        dur_half = 0.5 * self.dur
+        left_idx, right_idx = 0, 0
+        time_diff_dur_minus, time_diff_dur_plus = self.time - dur_half, self.time + dur_half
+        phase_sorted_idxs = np.argsort(phase)
+        phase_sorted = phase[phase_sorted_idxs]
+        dur_per_frac_half = 0.5 * self.qtran
         for i in np.arange(N):
-            # Get individual transit depth at this cadence, i.e. only use datapoints close in time
-            in_tran = abs(self.time - self.time[i]) < 0.5 * self.dur
-            n_SES[i] = np.sum(in_tran)
-            dep_SES[i] = self.zpt - weighted_mean(
-                self.flux[in_tran], self.flux_err[in_tran]
-            )
+            
+            # time is sorted; # Get individual transit depth at this cadence, i.e. only use datapoints close in time
+            while left_idx < N and self.time[left_idx] < time_diff_dur_minus[i]:
+                left_idx += 1
+            if right_idx < left_idx:
+                right_idx = left_idx
+            while right_idx < N and self.time[right_idx] <= time_diff_dur_plus[i]:
+                right_idx += 1
+            
+            n_SES[i] = right_idx - left_idx
+            dep_SES[i] = self.zpt - weighted_mean(self.flux[left_idx:right_idx], self.flux_err[left_idx:right_idx])
+            
             # Get overall transit depth at this cadence, i.e. use all datapoints close in phase
-            all_tran = (abs(phase - phase[i]) < 0.5 * self.qtran) | (
-                abs(phase - phase[i]) > 1 - 0.5 * self.qtran
-            )
-            n_MES[i] = np.sum(all_tran)
-            dep_MES[i] = self.zpt - weighted_mean(
-                self.flux[all_tran], self.flux_err[all_tran]
-            )
-            epochs = np.round((self.time - self.time[i]) / self.per)
-            tran_epochs = np.unique(epochs[all_tran])
-            N_transit_MES[i] = len(tran_epochs)
+            
+            # find indices within +- range from the current phase index
+            left_p  = np.searchsorted(phase_sorted, phase[i] - dur_per_frac_half, side='right')
+            right_p = np.searchsorted(phase_sorted, phase[i] + dur_per_frac_half, side='left')
+            idx_window = phase_sorted_idxs[left_p:right_p]
+
+            left_p_wrap  = np.searchsorted(phase_sorted, phase[i] - dur_per_frac_half + 1.0, side='right')
+            right_p_wrap = np.searchsorted(phase_sorted, phase[i] + dur_per_frac_half + 1.0, side='left')
+            idx_window_wrap = phase_sorted_idxs[left_p_wrap:right_p_wrap]
+
+            # combine the two windows
+            all_tran_idxs = np.concatenate((idx_window, idx_window_wrap))
+            
+            n_MES[i] = len(all_tran_idxs)
+            dep_MES[i] = self.zpt - weighted_mean(self.flux[all_tran_idxs], self.flux_err[all_tran_idxs])
+
+            # compute local epochs relative to current timestamp            
+            all_tran_time = self.time[all_tran_idxs]
+            local_epochs = np.round((all_tran_time - self.time[i]) / self.per)
+            N_transit_MES[i] = len(np.unique(local_epochs))
+            
             # Get running mean and uncertainty of out-of-transit fluxes, binned over transit timescale
-            in_bin = in_tran & ~self.near_tran
-            bin_flux[i] = weighted_mean(self.flux[in_bin], self.flux_err[in_bin])
-            bin_flux_err[i] = weighted_err(self.flux[in_bin], self.flux_err[in_bin])
+            mask_near_tran = ~self.near_tran[left_idx:right_idx]
+            bin_flux[i] = weighted_mean(self.flux[left_idx:right_idx][mask_near_tran], 
+                                        self.flux_err[left_idx:right_idx][mask_near_tran])
+            bin_flux_err[i] = weighted_err(self.flux[left_idx:right_idx][mask_near_tran], 
+                                           self.flux_err[left_idx:right_idx][mask_near_tran])
+            
         # Estimate white and red noise following Hartman & Bakos (2016)
         mask = ~np.isnan(bin_flux) & ~self.near_tran
         std = weighted_std(self.flux[mask], self.flux_err[mask])


### PR DESCRIPTION
Hi! 👋🦁

Sending this pull request to optimize the computation of MES and SES. I think it is particularly relevant for multi-sector TCEs where the number of timestamps can be considerable.

**FIX:** sped up computation of MES and SES from O(n^2) to O(n*log(n)), where n is the number of timestamps.

**TESTS:** Tested with TESS SPOC 2-min TIC 229685063.1 S14-S41:

- Non-optimized run: ~300 seconds to compute metrics + run FA/FP tests.
- Optimized run: ~10 seconds

Output: 
- same MES and SES. 
- **SHP metric slightly different** (I believe due to the way the edges are chosen for the windows inside the loop - if important, I think there should be a way to reproduce the exact same indices); SHP value before: 0.259229; after: 0.260575.

Let me know if you find a bug in my suggestion.

Cheers,

Miguel